### PR TITLE
Fix Laravel 13 model boot tenant scopes

### DIFF
--- a/src/BelongsToTenants.php
+++ b/src/BelongsToTenants.php
@@ -25,8 +25,15 @@ trait BelongsToTenants
         // Grab our singleton from the container
         static::$landlord = app(TenantManager::class);
 
-        // Add a global scope for each tenant this model should be scoped by.
-        static::$landlord->applyTenantScopes(new static());
+        if (method_exists(static::class, 'whenBooted')) {
+            static::whenBooted(function () {
+                // Add a global scope for each tenant this model should be scoped by.
+                static::$landlord->applyTenantScopes(new static());
+            });
+        } else {
+            // Add a global scope for each tenant this model should be scoped by.
+            static::$landlord->applyTenantScopes(new static());
+        }
 
         // Add tenantColumns automatically when creating models
         static::creating(function (Model $model) {


### PR DESCRIPTION
## Summary

This updates the `BelongsToTenants` trait so the tenant scope is registered after the model has finished booting.

Laravel 13 now prevents a model from creating a new instance of itself while that same model class is still booting. Samehouse currently does this inside `bootBelongsToTenants()` via `new static()`, which can trigger Laravel’s new guard.

By deferring the tenant scope registration with Laravel’s `whenBooted()` callback, we keep the existing trait boot behaviour intact while avoiding nested model booting.

## What changed

- Deferred tenant scope registration until the model has finished booting
- Removed the need to instantiate the model while its class is still booting
- Preserved the existing tenant scoping behaviour for models using `BelongsToTenants`